### PR TITLE
Fix single-line comment config change in vscode june 2025 release

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -519,16 +519,24 @@ export class Configuration {
 			// If the config object has own property of comments AND the comments key has
 			// own property of lineComment...
 			if (Object.hasOwn(config, "comments") && Object.hasOwn(config.comments, "lineComment")) {
+				let lineComment = config.comments.lineComment;
+
+				// Line comments can be a string or an object with a "comment" key.
+				// If the lineComment is an object, get the "comment" key value.
+				if (Object.hasOwn(lineComment, "comment")) {
+					lineComment = lineComment.comment;
+				}
+
 				// If the lineComment is "//"...
-				if (config.comments.lineComment === "//") {
+				if (lineComment === "//") {
 					style = "//";
 				}
 				// If the lineComment is "#"...
-				else if (config.comments.lineComment === "#") {
+				else if (lineComment === "#") {
 					style = "#";
 				}
 				// If the lineComment includes a ";" (; or ;;)...
-				else if (config.comments.lineComment.includes(";")) {
+				else if (lineComment.includes(";")) {
 					style = ";";
 				}
 


### PR DESCRIPTION
Fixes yCodeTech/auto-comment-blocks#10

In the `setSingleLineCommentLanguageDefinitions` method, it uses the `String.includes` method to detect when the `lineComment` string `includes` a semi-colon - ;.  The `lineComment` the language config has changed to be either a string or an object. The object has a `comment` and `noIndent` keys.

The `includes` method fails due to it being an object and errors out with "lineComment.includes is not a function".

To fix:

- Added a check to see if the `lineComment` is an object with a `comment` key inside, if it does then use the string value of the `comment` key. Otherwise, it will use the string value of the `lineComment`.