### PR TITLE
fix: update vscode types package and clean up now unused line comment types

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 	"devDependencies": {
 		"@types/mocha": "^10.0.9",
 		"@types/node": "^22.9.0",
-		"@types/vscode": "^1.96",
+		"@types/vscode": "^1.110",
 		"mocha": "^10.8.2",
 		"typescript": "^5.7"
 	},

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,7 +12,7 @@ import {logger} from "./logger";
 import * as utils from "./utils";
 import {ExtensionData} from "./extensionData";
 import {Settings} from "./interfaces/settings";
-import {ExtraSingleLineCommentStyles, LineComment, SingleLineCommentStyle} from "./interfaces/commentStyles";
+import {ExtraSingleLineCommentStyles, SingleLineCommentStyle} from "./interfaces/commentStyles";
 import {ExtensionMetaData} from "./interfaces/extensionMetaData";
 import {JsonObject, JsonArray, LanguageId, MultiLineLanguageDefinitions, SingleLineLanguageDefinitions} from "./interfaces/utils";
 import {CommandRegistration} from "./interfaces/commands";
@@ -599,7 +599,7 @@ export class Configuration {
 			// If the config object has own property of comments AND the comments key has
 			// own property of lineComment...
 			if (Object.hasOwn(config, "comments") && Object.hasOwn(config.comments, "lineComment")) {
-				let lineComment: LineComment = config.comments.lineComment as LineComment;
+				let lineComment = config.comments.lineComment;
 
 				// Line comments can be a string or an object with a "comment" key.
 				// If the lineComment is an object, get the "comment" key value.

--- a/src/interfaces/commentStyles.ts
+++ b/src/interfaces/commentStyles.ts
@@ -7,35 +7,3 @@ export type SingleLineCommentStyle = "//" | "#" | ";";
  * Define the extra single-line comment styles, like `///`, etc.
  */
 export type ExtraSingleLineCommentStyles = "##" | ";;" | "///" | "//!";
-
-/**
- * Line Comments
- *
- * Taken directly from VScode's commit in June 2025 that changed the line comment config.
- * https://github.com/microsoft/vscode/commit/d9145a291dcef0bad3ace81a3d55727ca294c122#diff-0dfa7db579eface8250affb76bc88717725a121401d4d8598bc36b92b0b6ef62
- *
- * The @types/vscode package does not yet have these changes.
- * So until they're added, we define them manually.
- */
-
-/**
- * The line comment token, like `// this is a comment`.
- * Can be a string, an object with comment and optional noIndent properties, or null.
- */
-export type LineComment = string | LineCommentConfig | null;
-
-/**
- * Configuration for line comments.
- */
-export interface LineCommentConfig {
-	/**
-	 * The line comment token, like `//`
-	 */
-	comment: string;
-
-	/**
-	 * Whether the comment token should not be indented and placed at the first column.
-	 * Defaults to false.
-	 */
-	noIndent?: boolean;
-}


### PR DESCRIPTION
VScode updated their types to include the LineComment typings and released 1.110 of @types/vscode package. So our temporary custom `LineComment` type and `LineCommentConfig` interface is now redundant.

- Updated @types/vscode package to 1.110.
- Removed the temporary `LineComment` type and `LineCommentConfig` interface, and removed the references in configuration file.