### PR TITLE
fix: JSON parsing with trailing commas enabled

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,8 @@ export function readJsonFile<T extends JsonValue = JsonObject>(filepath: string,
 		.toString()
 		.replace(/^\uFEFF/, ""); // Remove BOM if present.
 
-	const jsonContents = jsonc.parse(fileContent, jsonErrors, {allowEmptyContent: true}) ?? {};
+	// Parse the JSON content using jsonc-parser, allowing empty content and trailing commas.
+	const jsonContents = jsonc.parse(fileContent, jsonErrors, {allowEmptyContent: true, allowTrailingComma: true}) ?? {};
 
 	if (jsonErrors.length > 0) {
 		const errorMessages = constructJsonParseErrorMsg(filepath, fileContent, jsonErrors);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,19 +79,18 @@ function constructJsonParseErrorMsg(filepath: string, fileContent: string, jsonE
 	return jsonErrors
 		.map((err, i) => {
 			// Get the error name from the numeric error code.
-			// The name is PascalCased, so we need to format it by adding spaces
+			const errorName = jsonc.printParseErrorCode(err.error);
+
+			// The error name is PascalCased, so we need to format it by adding spaces
 			// before capital letters for readability.
-			const errorName = jsonc
-				.printParseErrorCode(err.error)
-				.replace(/([A-Z])/g, " $1")
-				.trim();
+			const errorNameFormatted = errorName.replace(/([A-Z])/g, " $1").trim();
 
 			// Calculate line and column numbers from the error offset.
 			const lineNumber = fileContent.substring(0, err.offset).split("\n").length;
 			const columnNumber = err.offset - fileContent.lastIndexOf("\n", err.offset - 1);
 
 			// Return the formatted error message.
-			return `\tError ${i + 1} - ${errorName} at "${filepath}:${lineNumber}:${columnNumber}"\n`;
+			return `\tError ${i + 1} [${errorName}] - ${errorNameFormatted} at "${filepath}:${lineNumber}:${columnNumber}"\n`;
 		})
 		.join("\n");
 }


### PR DESCRIPTION
Fixes #36.

**The issue**

This extension uses [jsonc-parser](https://github.com/microsoft/node-jsonc-parser) to make sure the syntax of the JSON is correct and not malformed. During parsing of JSON files, the parser will throw a `ValueExpected` error when it reaches a comma and unexpectedly encounters a closing bracket straight after. Trailing commas are disabled in the parser by default as it's not standard in JSON or JSONC. So it expects some kind of value after all commas.

**The fix**

Luckily, the parser has an option to enable trailing commas. So the fix is to just pass the `allowTrailingComma: true` option to the parser in the `readJsonFile` util function. This will then skip over and prevent the `ValueExpected` error for trailing commas.

---

**Copilot Summary**

This pull request improves the robustness and clarity of JSON file parsing in the `src/utils.ts` utility functions. The key changes enhance error handling and allow for more flexible JSON syntax.

**JSON parsing improvements:**

* The `readJsonFile` function now allows trailing commas in JSON files by setting the `allowTrailingComma: true` option in the `jsonc.parse` call. This makes the parser more permissive and user-friendly.

**Error reporting enhancements:**

* The `constructJsonParseErrorMsg` function now includes both the raw error code (in brackets) and a more readable, space-separated error name in its output. This provides clearer and more informative error messages for debugging JSON parsing issues.