### PR TITLE
refactor: logging environment variables

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1017,7 +1017,9 @@ export class Configuration {
 				"Version": vscode.version,
 				"Remote Name": vscode.env.remoteName || "local",
 				"Host": vscode.env.appHost,
+				"App Root": vscode.env.appRoot,
 				...extensionsPaths,
+				"Env Vars": Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith("VSCODE_"))),
 			},
 		};
 		logger.debug("Environment:", env);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -986,30 +986,6 @@ export class Configuration {
 			return;
 		}
 
-		// The path to the built-in extensions. The env variable changes when on WSL.
-		// So we can use it for both Windows and WSL.
-		const builtInExtensionsPath = this.extensionData.getExtensionDiscoveryPath("builtInExtensionsPath");
-
-		let extensionsPaths: JsonObject = {};
-
-		if (isWsl) {
-			// Get the Windows user and built-in extensions paths.
-			const windowsUserExtensionsPath = this.extensionData.getExtensionDiscoveryPath("WindowsUserExtensionsPathFromWsl");
-			const windowsBuiltInExtensionsPath = this.extensionData.getExtensionDiscoveryPath("WindowsBuiltInExtensionsPathFromWsl");
-
-			extensionsPaths = {
-				"Windows-installed Built-in Extensions Path": windowsBuiltInExtensionsPath,
-				"Windows-installed User Extensions Path": windowsUserExtensionsPath,
-				"WSL-installed Built-in Extensions Path": builtInExtensionsPath,
-				"WSL-installed User Extensions Path": this.extensionData.getExtensionDiscoveryPath("userExtensionsPath"),
-			};
-		} else {
-			extensionsPaths = {
-				"Built-in Extensions Path": builtInExtensionsPath,
-				"User Extensions Path": this.extensionData.getExtensionDiscoveryPath("userExtensionsPath"),
-			};
-		}
-
 		const env: JsonObject = {
 			"OS": process.platform,
 			"Platform": process.platform,
@@ -1018,7 +994,6 @@ export class Configuration {
 				"Remote Name": vscode.env.remoteName || "local",
 				"Host": vscode.env.appHost,
 				"App Root": vscode.env.appRoot,
-				...extensionsPaths,
 				"Env Vars": Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith("VSCODE_"))),
 			},
 		};
@@ -1028,12 +1003,20 @@ export class Configuration {
 		logger.debug("Configuration settings:", this.getConfiguration());
 
 		// Log the objects for debugging purposes.
+
+		// Lang Config Filepaths.
 		logger.debug("The language config filepaths found are:", this.languageConfigFilePaths);
+
+		// Lang Configs.
 		logger.debug("The language configs found are:", this.languageConfigs);
+
+		// Multi-line language definitions.
 		logger.debug(
 			"The supported languages for multi-line blocks:",
 			utils.readJsonFile<MultiLineLanguageDefinitions>(this.multiLineLangDefinitionFilePath)
 		);
+
+		// Single-line language definitions.
 		logger.debug(
 			"The supported languages for single-line blocks:",
 			utils.readJsonFile<SingleLineLanguageDefinitions>(this.singleLineLangDefinitionFilePath)

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -994,7 +994,12 @@ export class Configuration {
 				"Remote Name": vscode.env.remoteName || "local",
 				"Host": vscode.env.appHost,
 				"App Root": vscode.env.appRoot,
-				"Env Vars": Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith("VSCODE_"))),
+				"Env Vars": Object.fromEntries(
+					Object.entries(process.env).filter((entry): entry is [string, string] => {
+						const [key, value] = entry;
+						return key.startsWith("VSCODE_") && typeof value === "string";
+					})
+				),
 			},
 		};
 		logger.debug("Environment:", env);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1019,7 +1019,6 @@ export class Configuration {
 				"Host": vscode.env.appHost,
 				...extensionsPaths,
 			},
-			"Other System Env Variables": process.env,
 		};
 		logger.debug("Environment:", env);
 


### PR DESCRIPTION
This pull request updates the way environment and extension path information is logged in the `Configuration` class, streamlining the debug output and focusing on relevant environment variables. The most important changes are:

**Environment and Extension Path Logging:**

* Removed the logging of the extension discovery paths from the `logDebugInfo` method as these are also logged in `extension.ts`, so they're technically redundant in the method.
* Added logging of the `App Root` and filtered environment variables (only those starting with `VSCODE_`) under `Env Vars` in the environment details, making the debug output more focused and relevant in `logDebugInfo` method.

**Removal of dumping system environment variables into the logs**

* Removed logging of the dumped system environment variables as they could potentially have some sensitive information like environment passwords, auth keys, etc. Majority of it wasn't relevant to debugging anyway.