### PR TITLE
feat: redact username in logging paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,12 +85,14 @@
 					"enum": [
 						"debug",
 						"info",
+						"warn",
 						"error",
 						"off"
 					],
 					"markdownEnumDescriptions": [
-						"Log debug, info, and errors",
-						"Log info and errors",
+						"Log debug, info, warnings, and errors",
+						"Log info, warnings, and errors",
+						"Log warnings and errors",
 						"Log errors only",
 						"Disable logging"
 					],

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1003,7 +1003,7 @@ export class Configuration {
 			},
 		};
 
-		logger.debug("Environment:", utils.redactUsername(env));
+		logger.debug("Environment:", env);
 
 		// Log the extension's user configuration settings.
 		logger.debug("Configuration settings:", this.getConfiguration());
@@ -1011,7 +1011,7 @@ export class Configuration {
 		// Log the objects for debugging purposes.
 
 		// Lang Config Filepaths.
-		logger.debug("The language config filepaths found are:", utils.redactUsername(this.languageConfigFilePaths));
+		logger.debug("The language config filepaths found are:", this.languageConfigFilePaths);
 
 		// Lang Configs.
 		logger.debug("The language configs found are:", this.languageConfigs);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1002,7 +1002,8 @@ export class Configuration {
 				),
 			},
 		};
-		logger.debug("Environment:", env);
+
+		logger.debug("Environment:", utils.redactUsername(env));
 
 		// Log the extension's user configuration settings.
 		logger.debug("Configuration settings:", this.getConfiguration());
@@ -1010,7 +1011,7 @@ export class Configuration {
 		// Log the objects for debugging purposes.
 
 		// Lang Config Filepaths.
-		logger.debug("The language config filepaths found are:", this.languageConfigFilePaths);
+		logger.debug("The language config filepaths found are:", utils.redactUsername(this.languageConfigFilePaths));
 
 		// Lang Configs.
 		logger.debug("The language configs found are:", this.languageConfigs);

--- a/src/extensionData.ts
+++ b/src/extensionData.ts
@@ -5,7 +5,7 @@ import isWsl from "is-wsl";
 import {IPackageJson} from "package-json-type";
 
 import {logger} from "./logger";
-import {readJsonFile, redactUsername} from "./utils";
+import {readJsonFile} from "./utils";
 import {ExtensionMetaData, ExtensionPaths, ExtensionMetaDataValue} from "./interfaces/extensionMetaData";
 
 export class ExtensionData {
@@ -334,10 +334,6 @@ export class ExtensionData {
 		// Remove the packageJSON entry to avoid logging irrelevant information.
 		extensionDataClone.delete("packageJSON");
 
-		// Redact the username in the extensionPath.
-		const redactedExtensionPath = redactUsername(extensionDataClone.get("extensionPath"));
-		extensionDataClone.set("extensionPath", redactedExtensionPath);
-
 		return extensionDataClone;
 	}
 
@@ -360,6 +356,6 @@ export class ExtensionData {
 	 */
 	public getAllExtensionDiscoveryPaths(): ReadonlyMap<keyof ExtensionPaths, string> {
 		// Return a new Map to prevent external mutation of the internal state.
-		return new Map(redactUsername(this.extensionDiscoveryPaths));
+		return new Map(this.extensionDiscoveryPaths);
 	}
 }

--- a/src/extensionData.ts
+++ b/src/extensionData.ts
@@ -350,10 +350,12 @@ export class ExtensionData {
 
 	/**
 	 * Get all extension discovery paths.
+	 * Used for logging the paths to the output channel.
 	 *
 	 * @returns {ReadonlyMap<keyof ExtensionPaths, string>} A read-only Map containing all extension discovery paths.
 	 */
 	public getAllExtensionDiscoveryPaths(): ReadonlyMap<keyof ExtensionPaths, string> {
-		return this.extensionDiscoveryPaths;
+		// Return a new Map to prevent external mutation of the internal state.
+		return new Map(this.extensionDiscoveryPaths);
 	}
 }

--- a/src/extensionData.ts
+++ b/src/extensionData.ts
@@ -5,7 +5,7 @@ import isWsl from "is-wsl";
 import {IPackageJson} from "package-json-type";
 
 import {logger} from "./logger";
-import {readJsonFile} from "./utils";
+import {readJsonFile, redactUsername} from "./utils";
 import {ExtensionMetaData, ExtensionPaths, ExtensionMetaDataValue} from "./interfaces/extensionMetaData";
 
 export class ExtensionData {
@@ -334,6 +334,10 @@ export class ExtensionData {
 		// Remove the packageJSON entry to avoid logging irrelevant information.
 		extensionDataClone.delete("packageJSON");
 
+		// Redact the username in the extensionPath.
+		const redactedExtensionPath = redactUsername(extensionDataClone.get("extensionPath"));
+		extensionDataClone.set("extensionPath", redactedExtensionPath);
+
 		return extensionDataClone;
 	}
 
@@ -356,6 +360,6 @@ export class ExtensionData {
 	 */
 	public getAllExtensionDiscoveryPaths(): ReadonlyMap<keyof ExtensionPaths, string> {
 		// Return a new Map to prevent external mutation of the internal state.
-		return new Map(this.extensionDiscoveryPaths);
+		return new Map(redactUsername(this.extensionDiscoveryPaths));
 	}
 }

--- a/src/interfaces/utils.ts
+++ b/src/interfaces/utils.ts
@@ -44,6 +44,7 @@ export type LanguageId = string;
 export const logLevels = {
 	debug: "debug",
 	info: "info",
+	warn: "warn",
 	error: "error",
 	off: "off",
 } as const;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -27,6 +27,14 @@ class Logger {
 	 */
 	private logLevel: LogLevel = "debug";
 
+	/**
+	 * Whether the user has already been warned that username redaction is unavailable,
+	 * so the warning is only emitted once per session.
+	 *
+	 * @type {boolean}
+	 */
+	private hasWarnedAboutRedactionFailure: boolean = false;
+
 	/***********
 	 * Methods *
 	 ***********/
@@ -98,6 +106,17 @@ class Logger {
 	}
 
 	/**
+	 * Sends a warning log to the output channel.
+	 *
+	 * @param {string} message The message to be logged.
+	 */
+	public warn(message: string): void {
+		if (this.shouldLog("warn")) {
+			this.logMessage("WARN", message);
+		}
+	}
+
+	/**
 	 * Sends a debug log message and data to the output channel if `debug` is enabled.
 	 * This is helpful for logging objects and arrays.
 	 *
@@ -151,8 +170,9 @@ class Logger {
 	private shouldLog(requiredLevel: LogLevel): boolean {
 		// Numeric weights used for level comparison.
 		const levelWeight: Record<LogLevel, number> = {
-			debug: 3, // Emits debug, info, and error logs - the most verbose level.
-			info: 2, // Emits info and error logs.
+			debug: 4, // Emits debug, info, warn, and error logs - the most verbose level.
+			info: 3, // Emits info, warn, and error logs.
+			warn: 2, // Emits warn and error logs.
 			error: 1, // Emits error logs only.
 			off: 0, // Disables all logs, except for the special "important" logs that are always emitted.
 		};
@@ -251,11 +271,13 @@ class Logger {
 		try {
 			username = os.userInfo().username;
 		} catch {
+			this.warnOnRedactionFailure();
 			return text;
 		}
 
 		// If the username is empty, return the original text.
 		if (!username) {
+			this.warnOnRedactionFailure();
 			return text;
 		}
 
@@ -263,6 +285,18 @@ class Logger {
 		const escapedUsername = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 		// Replace any occurrence of the username in the text with "<redacted>", case-insensitively, and return it.
 		return text.replace(new RegExp(escapedUsername, "gi"), "<redacted>");
+	}
+
+	/**
+	 * Warn once per session that debug logs may not have the username redacted,
+	 * so users don't unknowingly share it in a bug report.
+	 */
+	private warnOnRedactionFailure(): void {
+		if (this.hasWarnedAboutRedactionFailure) {
+			return;
+		}
+		this.hasWarnedAboutRedactionFailure = true;
+		this.warn("Could not determine OS username; debug logs may not be redacted before sharing.");
 	}
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -267,6 +267,11 @@ class Logger {
 	 * @returns {string} The text with OS username replaced with `<redacted>`.
 	 */
 	private redactUsername(text: string): string {
+		// If redaction previously failed, skip attempting it again and return the original text.
+		if (this.hasWarnedAboutRedactionFailure) {
+			return text;
+		}
+
 		let username: string;
 
 		// Get the current OS username using Node's userInfo() method which is

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -192,13 +192,18 @@ class Logger {
 		if (!this.outputChannel) {
 			this.setupOutputChannel();
 		}
+
+		message = this.redactUsername(message);
+
 		const time = new Date().toLocaleTimeString();
 
 		// Output the log message to the output channel.
 		this.outputChannel.append(`["${level}" - ${time}] ${message}`);
 
 		if (meta) {
-			const data: string = this.formatMeta(message, meta);
+			let data: string = this.formatMeta(message, meta);
+
+			data = this.redactUsername(data);
 
 			// Output the meta data to the output channel with a leading space.
 			this.outputChannel.appendLine(` ${data}`);
@@ -229,7 +234,7 @@ class Logger {
 			data = lines.join(",\n");
 		}
 
-		return this.redactUsername(data);
+		return data;
 	}
 
 	/**

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import {OutputChannel, window} from "vscode";
 import {LogLevel, logLevels} from "./interfaces/utils";
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -106,17 +106,6 @@ class Logger {
 	}
 
 	/**
-	 * Sends a warning log to the output channel.
-	 *
-	 * @param {string} message The message to be logged.
-	 */
-	public warn(message: string): void {
-		if (this.shouldLog("warn")) {
-			this.logMessage("WARN", message);
-		}
-	}
-
-	/**
 	 * Sends a debug log message and data to the output channel if `debug` is enabled.
 	 * This is helpful for logging objects and arrays.
 	 *
@@ -138,6 +127,17 @@ class Logger {
 	public error(message: string, error?: Error): void {
 		if (this.shouldLog("error")) {
 			this.logMessage("ERROR", message, error);
+		}
+	}
+
+	/**
+	 * Sends a warning log to the output channel.
+	 *
+	 * @param {string} message The message to be logged.
+	 */
+	public warn(message: string): void {
+		if (this.shouldLog("warn")) {
+			this.logMessage("WARN", message);
 		}
 	}
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -296,7 +296,7 @@ class Logger {
 			return;
 		}
 		this.hasWarnedAboutRedactionFailure = true;
-		this.warn("Could not determine OS username; debug logs may not be redacted before sharing.");
+		this.warn("Could not determine OS username; logs won't be redacted. Manually redact any sensitive information before sharing logs.");
 	}
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -28,12 +28,13 @@ class Logger {
 	private logLevel: LogLevel = "debug";
 
 	/**
-	 * Whether the user has already been warned that username redaction is unavailable,
-	 * so the warning is only emitted once per session.
+	 * Whether username redaction should be skipped, because it previously failed.
+	 * Once set, further attempts are not made since the username is unlikely to become
+	 * resolvable later in the same session.
 	 *
 	 * @type {boolean}
 	 */
-	private hasWarnedAboutRedactionFailure: boolean = false;
+	private skipRedaction: boolean = false;
 
 	/***********
 	 * Methods *
@@ -260,15 +261,16 @@ class Logger {
 	}
 
 	/**
-	 * Redact the OS username from a string, replacing it with `<redacted>`, to avoid leaking
-	 * it into debug logs that could be shared.
+	 * Redact the OS username from a string, replacing it with `<redacted>`,
+	 * to avoid leaking it into the logs that could be shared.
 	 *
 	 * @param {string} text The text to redact.
-	 * @returns {string} The text with OS username replaced with `<redacted>`.
+	 * @returns {string} If redaction was possible, returns the redacted text,
+	 * otherwise the original text.
 	 */
 	private redactUsername(text: string): string {
 		// If redaction previously failed, skip attempting it again and return the original text.
-		if (this.hasWarnedAboutRedactionFailure) {
+		if (this.skipRedaction) {
 			return text;
 		}
 
@@ -302,10 +304,8 @@ class Logger {
 	 * so users don't unknowingly share it in a bug report.
 	 */
 	private warnOnRedactionFailure(): void {
-		if (this.hasWarnedAboutRedactionFailure) {
-			return;
-		}
-		this.hasWarnedAboutRedactionFailure = true;
+		// Set the flag to skip further redaction attempts before warning to avoid recursion.
+		this.skipRedaction = true;
 		this.warn("Could not determine OS username; logs won't be redacted. Manually redact any sensitive information before sharing logs.");
 	}
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -208,7 +208,7 @@ class Logger {
 			data = lines.join(",\n");
 		}
 
-		return data;
+		return this.redactUsername(data);
 	}
 
 	/**
@@ -231,6 +231,37 @@ class Logger {
 		}
 
 		return value;
+	}
+
+	/**
+	 * Redact the OS username from a string, replacing it with `<redacted>`, to avoid leaking
+	 * it into debug logs that could be shared.
+	 *
+	 * @param {string} text The text to redact.
+	 * @returns {string} The text with OS username replaced with `<redacted>`.
+	 */
+	private redactUsername(text: string): string {
+		let username: string;
+
+		// Get the current OS username using Node's userInfo() method which is
+		// cross-platform compatible. It can throw an error in sandboxed/remote environments where
+		// the username can't be determined. So catch any errors and return the original text
+		// if we can't get the username.
+		try {
+			username = os.userInfo().username;
+		} catch {
+			return text;
+		}
+
+		// If the username is empty, return the original text.
+		if (!username) {
+			return text;
+		}
+
+		// Escape special characters in the username.
+		const escapedUsername = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		// Replace any occurrence of the username in the text with "<redacted>", case-insensitively, and return it.
+		return text.replace(new RegExp(escapedUsername, "gi"), "<redacted>");
 	}
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as jsonc from "jsonc-parser";
 import {logger} from "./logger";
@@ -252,6 +253,59 @@ export function mergeArraysBy<T>(primaryArray: T[], secondaryArray: T[], key: ke
 	});
 
 	return merged;
+}
+
+/**
+ * Recursively redact the OS username from strings within a value (including
+ * nested objects, arrays, and Maps), replacing it with "<redacted>".
+ *
+ * @param {T} value The value to sanitize.
+ * @returns {T} A sanitized copy of `value` with the username redacted.
+ */
+export function redactUsername<T>(value: T): T {
+	// Get the current OS username using Node's userInfo() method which is
+	// cross-platform compatible.
+	const username = os.userInfo().username;
+	// Escape special characters in the username.
+	const escapedUsername = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	// Build a global case-insensitive regex if username isn't an empty string.
+	const usernameRegex = username ? new RegExp(escapedUsername, "gi") : null;
+
+	/**
+	 * Recursively redacts the OS username from strings within a value.
+	 * @param input The value to sanitize.
+	 * @returns The sanitized value with the username redacted.
+	 */
+	const redact = (input: unknown): unknown => {
+		// If the input is a string, replace any occurrences of the username with "<redacted>".
+		if (typeof input === "string") {
+			let result = input;
+
+			if (usernameRegex) {
+				result = result.replace(usernameRegex, "<redacted>");
+			}
+			return result;
+		}
+
+		// If the input is an array, recursively redact each element.
+		if (Array.isArray(input)) {
+			return input.map(redact);
+		}
+
+		// If the input is a Map, recursively redact each value and return a new Map.
+		if (input instanceof Map) {
+			return new Map([...input].map(([key, val]) => [key, redact(val)]));
+		}
+
+		// If the input is an object, recursively redact each value and return a new object.
+		if (input !== null && typeof input === "object") {
+			return Object.fromEntries(Object.entries(input).map(([key, val]) => [key, redact(val)]));
+		}
+
+		return input;
+	};
+
+	return redact(value) as T;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import * as jsonc from "jsonc-parser";
 import {logger} from "./logger";
@@ -253,59 +252,6 @@ export function mergeArraysBy<T>(primaryArray: T[], secondaryArray: T[], key: ke
 	});
 
 	return merged;
-}
-
-/**
- * Recursively redact the OS username from strings within a value (including
- * nested objects, arrays, and Maps), replacing it with "<redacted>".
- *
- * @param {T} value The value to sanitize.
- * @returns {T} A sanitized copy of `value` with the username redacted.
- */
-export function redactUsername<T>(value: T): T {
-	// Get the current OS username using Node's userInfo() method which is
-	// cross-platform compatible.
-	const username = os.userInfo().username;
-	// Escape special characters in the username.
-	const escapedUsername = username.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	// Build a global case-insensitive regex if username isn't an empty string.
-	const usernameRegex = username ? new RegExp(escapedUsername, "gi") : null;
-
-	/**
-	 * Recursively redacts the OS username from strings within a value.
-	 * @param input The value to sanitize.
-	 * @returns The sanitized value with the username redacted.
-	 */
-	const redact = (input: unknown): unknown => {
-		// If the input is a string, replace any occurrences of the username with "<redacted>".
-		if (typeof input === "string") {
-			let result = input;
-
-			if (usernameRegex) {
-				result = result.replace(usernameRegex, "<redacted>");
-			}
-			return result;
-		}
-
-		// If the input is an array, recursively redact each element.
-		if (Array.isArray(input)) {
-			return input.map(redact);
-		}
-
-		// If the input is a Map, recursively redact each value and return a new Map.
-		if (input instanceof Map) {
-			return new Map([...input].map(([key, val]) => [key, redact(val)]));
-		}
-
-		// If the input is an object, recursively redact each value and return a new object.
-		if (input !== null && typeof input === "object") {
-			return Object.fromEntries(Object.entries(input).map(([key, val]) => [key, redact(val)]));
-		}
-
-		return input;
-	};
-
-	return redact(value) as T;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a new warning log level and improves logging safety by redacting OS usernames in paths from log output. It also refines the handling of extension discovery paths and updates log level descriptions for clarity.

**Logging improvements:**

* Added a new `warn` log level, including support in the logger, log level comparisons, and the `logLevels` utils constant.
* Implemented automatic redaction of the current OS username from all log messages and data to prevent accidental leaking of sensitive information. If the username cannot be determined, a warning is logged once per session while avoiding infinite recursion, and further redaction attempts are skipped.

**Configuration and API updates:**

* Updated log level descriptions in `package.json` to reflect the new `warn` level and clarify which messages are included at each level.
* The `getAllExtensionDiscoveryPaths` method now returns a new `Map` to prevent external mutation of internal state.

**Other changes:**

* Minor code formatting and comments for clarity in configuration and extension data classes.